### PR TITLE
feat: Add autofill for email+password

### DIFF
--- a/you-have-mail-android/app/src/main/java/dev/lbeernaert/youhavemail/components/PasswordField.kt
+++ b/you-have-mail-android/app/src/main/java/dev/lbeernaert/youhavemail/components/PasswordField.kt
@@ -14,14 +14,19 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.autofill.AutofillType
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.input.VisualTransformation
+import dev.lbeernaert.youhavemail.ui.AutoFillRequestHandler
+import dev.lbeernaert.youhavemail.ui.autofill
 
 
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun PasswordField(
     placeHolder: String,
@@ -31,8 +36,15 @@ fun PasswordField(
     val showPassword = remember {
         mutableStateOf(false)
     }
+    val autoFillHandler = AutoFillRequestHandler(
+        autofillTypes = listOf(AutofillType.Password),
+        onFill = { state.value = TextFieldValue(it) }
+    )
+
     TextField(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier
+            .fillMaxWidth()
+            .autofill(handler = autoFillHandler),
         label = { Text(text = placeHolder) },
         value = state.value,
         singleLine = true,

--- a/you-have-mail-android/app/src/main/java/dev/lbeernaert/youhavemail/screens/Login.kt
+++ b/you-have-mail-android/app/src/main/java/dev/lbeernaert/youhavemail/screens/Login.kt
@@ -15,7 +15,9 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.autofill.AutofillType
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
@@ -25,8 +27,11 @@ import dev.lbeernaert.youhavemail.R
 import dev.lbeernaert.youhavemail.components.ActionButton
 import dev.lbeernaert.youhavemail.components.AsyncScreen
 import dev.lbeernaert.youhavemail.components.PasswordField
+import dev.lbeernaert.youhavemail.ui.AutoFillRequestHandler
+import dev.lbeernaert.youhavemail.ui.autofill
 
 
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun Login(
     backendName: String,
@@ -34,7 +39,7 @@ fun Login(
     onBackClicked: () -> Unit,
     onLoginClicked: suspend (email: String, password: String) -> Unit
 ) {
-    var email = rememberSaveable(stateSaver = TextFieldValue.Saver) {
+    val email = rememberSaveable(stateSaver = TextFieldValue.Saver) {
         mutableStateOf(
             TextFieldValue(accountEmail)
         )
@@ -53,6 +58,10 @@ fun Login(
                 onLoginClicked(email.value.text, password.value.text)
             }
         }
+        val autoFillHandler = AutoFillRequestHandler(
+            autofillTypes = listOf(AutofillType.EmailAddress),
+            onFill = { email.value = TextFieldValue(it) }
+        )
 
         Column(
             modifier = Modifier
@@ -68,7 +77,8 @@ fun Login(
             Spacer(modifier = Modifier.height(20.dp))
 
             TextField(
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier.fillMaxWidth()
+                    .autofill(handler = autoFillHandler),
                 label = { Text(text = "Email") },
                 singleLine = true,
                 value = email.value,

--- a/you-have-mail-android/app/src/main/java/dev/lbeernaert/youhavemail/ui/Autofill.kt
+++ b/you-have-mail-android/app/src/main/java/dev/lbeernaert/youhavemail/ui/Autofill.kt
@@ -1,0 +1,71 @@
+package dev.lbeernaert.youhavemail.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.autofill.AutofillNode
+import androidx.compose.ui.autofill.AutofillType
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.layout.boundsInWindow
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalAutofill
+import androidx.compose.ui.platform.LocalAutofillTree
+
+// This file is adapted from https://medium.com/@bagadeshrp/compose-ui-textfield-autofill-6e2ac434e380
+
+// The autofill modifier internally adds two modifiers:
+// one to setup the layout, and one to listen for focus events.
+@OptIn(ExperimentalComposeUiApi::class)
+fun Modifier.autofill(handler: AutoFillHandler): Modifier {
+    return this.then(
+        onGloballyPositioned {
+            handler.autoFillNode.boundingBox = it.boundsInWindow()
+        }
+    ).then(
+        onFocusChanged {
+            if (it.isFocused) {
+                handler.request()
+            } else {
+                handler.cancel()
+            }
+        }
+    )
+}
+
+@OptIn(ExperimentalComposeUiApi::class)
+@Composable
+fun AutoFillRequestHandler(
+    autofillTypes: List<AutofillType> = listOf(),
+    onFill: (String) -> Unit,
+): AutoFillHandler {
+    val autoFillNode = remember {
+        AutofillNode(
+            autofillTypes = autofillTypes,
+            onFill = { onFill(it) }
+        )
+    }
+    val autofill = LocalAutofill.current
+    LocalAutofillTree.current += autoFillNode
+    return remember {
+        object : AutoFillHandler {
+            override val autoFillNode: AutofillNode
+                get() = autoFillNode
+
+            override fun request() {
+                autofill?.requestAutofillForNode(autofillNode = autoFillNode)
+            }
+
+            override fun cancel() {
+                autofill?.cancelAutofillForNode(autofillNode = autoFillNode)
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalComposeUiApi::class)
+interface AutoFillHandler {
+    val autoFillNode: AutofillNode
+    fun request()
+    fun cancel()
+}


### PR DESCRIPTION
In traditional XML this would have been a single line change: `android:autofillHints="password"` 🥲

In Jetpack Compose it is:

- an experimental API
- for which the only good explanation on to use it is a private individual's [blog post](https://bryanherbst.com/2021/04/13/compose-autofill/) from 2021 (3 years ago...)

And even then Compose is buggy. On my Android 14 / LineageOS 21 device, the autofill popup reliably shows the first time you open the view. But if you click around a bit, e.g. click alternating in "email", "password", "email", etc, then at some point the autofill hints are not shown any more. Sometimes after the first iteration, sometime after the second or third.
Stepping through it with a debugger, the focus is set correctly, but somewhere inside `requestAutofillForNode()` it goes wrong. 🤷‍♂️

Ah, and for TOTP we can't have autofill. Classic XML has [an enum value](https://developer.android.com/reference/androidx/autofill/HintConstants#AUTOFILL_HINT_2FA_APP_OTP()) for TOTP, but Compose [does not](https://developer.android.com/reference/kotlin/androidx/compose/ui/autofill/AutofillType). 😂

Still, I find this a useful addition. It works, if you don't deviate from the direct path.